### PR TITLE
Fix: Correct class inheritance for global session timeout

### DIFF
--- a/app/src/main/java/com/gopi/securevault/ui/aadhar/AadharActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/aadhar/AadharActivity.kt
@@ -26,7 +26,7 @@ import com.gopi.securevault.util.AppConstants
 import java.io.File
 import java.io.FileOutputStream
 
-class AadharActivity : AppCompatActivity() {
+class AadharActivity : BaseActivity() {
     private lateinit var binding: ActivityAadharBinding
     private var selectedFileUri: Uri? = null
     private val dao by lazy { AppDatabase.get(this).aadharDao() }

--- a/app/src/main/java/com/gopi/securevault/ui/auth/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/auth/ChangePasswordActivity.kt
@@ -10,7 +10,7 @@ import com.gopi.securevault.util.CryptoPrefs
 import com.gopi.securevault.util.PasswordUtils
 import net.sqlcipher.database.SQLiteDatabase
 
-class ChangePasswordActivity : AppCompatActivity() {
+class ChangePasswordActivity : BaseActivity() {
 
     private lateinit var binding: ActivityChangePasswordBinding
     private lateinit var prefs: CryptoPrefs

--- a/app/src/main/java/com/gopi/securevault/ui/backup/BackupRestoreActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/backup/BackupRestoreActivity.kt
@@ -17,7 +17,7 @@ import com.gopi.securevault.util.CryptoPrefs
 import com.gopi.securevault.util.PasswordUtils
 import kotlinx.coroutines.launch
 
-class BackupRestoreActivity : AppCompatActivity() {
+class BackupRestoreActivity : BaseActivity() {
 
     private lateinit var binding: ActivityBackupRestoreBinding
     private lateinit var backupManager: BackupManager

--- a/app/src/main/java/com/gopi/securevault/ui/banks/BanksActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/banks/BanksActivity.kt
@@ -20,7 +20,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import androidx.appcompat.widget.TooltipCompat
 
-class BanksActivity : AppCompatActivity() {
+class BanksActivity : BaseActivity() {
     private lateinit var binding: ActivityBanksBinding
     private val dao by lazy { AppDatabase.get(this).bankDao() }
     private val adapter = BankAdapter(

--- a/app/src/main/java/com/gopi/securevault/ui/cards/CardsActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/cards/CardsActivity.kt
@@ -20,7 +20,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import androidx.appcompat.widget.TooltipCompat
 
-class CardsActivity : AppCompatActivity() {
+class CardsActivity : BaseActivity() {
     private lateinit var binding: ActivityCardsBinding
     private val dao by lazy { AppDatabase.get(this).cardDao() }
     private val adapter = CardAdapter(

--- a/app/src/main/java/com/gopi/securevault/ui/license/LicenseActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/license/LicenseActivity.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class LicenseActivity : AppCompatActivity() {
+class LicenseActivity : BaseActivity() {
     private lateinit var binding: ActivityLicenseBinding
     private var selectedFileUri: Uri? = null
     private val dao by lazy { AppDatabase.get(this).licenseDao() }

--- a/app/src/main/java/com/gopi/securevault/ui/misc/MiscActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/misc/MiscActivity.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class MiscActivity : AppCompatActivity() {
+class MiscActivity : BaseActivity() {
     private lateinit var binding: ActivityMiscBinding
     private var selectedFileUri: Uri? = null
     private val dao by lazy { AppDatabase.get(this).miscDao() }

--- a/app/src/main/java/com/gopi/securevault/ui/pan/PanActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/pan/PanActivity.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class PanActivity : AppCompatActivity() {
+class PanActivity : BaseActivity() {
     private lateinit var binding: ActivityPanBinding
     private var selectedFileUri: Uri? = null
     private val dao by lazy { AppDatabase.get(this).panDao() }

--- a/app/src/main/java/com/gopi/securevault/ui/policies/PoliciesActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/policies/PoliciesActivity.kt
@@ -16,7 +16,7 @@ import com.gopi.securevault.databinding.ItemPolicyBinding
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class PoliciesActivity : AppCompatActivity() {
+class PoliciesActivity : BaseActivity() {
     private lateinit var binding: ActivityPoliciesBinding
     private val dao by lazy { AppDatabase.get(this).policyDao() }
     private val adapter = PolicyAdapter(

--- a/app/src/main/java/com/gopi/securevault/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/settings/SettingsActivity.kt
@@ -16,7 +16,7 @@ import java.io.File
 
 import com.gopi.securevault.databinding.ActivitySettingsBinding
 
-class SettingsActivity : AppCompatActivity() {
+class SettingsActivity : BaseActivity() {
 
     private lateinit var binding: ActivitySettingsBinding
 

--- a/app/src/main/java/com/gopi/securevault/ui/voterid/VoterIdActivity.kt
+++ b/app/src/main/java/com/gopi/securevault/ui/voterid/VoterIdActivity.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 
-class VoterIdActivity : AppCompatActivity() {
+class VoterIdActivity : BaseActivity() {
     private lateinit var binding: ActivityVoterIdBinding
     private var selectedFileUri: Uri? = null
     private val dao by lazy { AppDatabase.get(this).voterIdDao() }


### PR DESCRIPTION
This commit fixes a build error caused by incorrect class inheritance in the activities that were modified to use the global session timeout.

The previous commit only changed the import statements, but not the class declarations. This commit corrects the class declarations to extend `BaseActivity` instead of `AppCompatActivity`.